### PR TITLE
Dockerfile first draft - DO NOT MERGE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Build Swift in Docker
+
+FROM fedora:23
+MAINTAINER David Sperling <dsperling@smithmicro.com>
+
+ENV BUILD_SCRIPT swiftbuild.sh
+
+WORKDIR /fedora-swift
+
+COPY *.sh *.ini ./
+
+# remove the unnecessary sudo commands
+RUN sed -i 's/sudo//g' $BUILD_SCRIPT
+
+RUN ./$BUILD_SCRIPT setup \
+  && ./$BUILD_SCRIPT update
+
+# This command currently fails with:
+# utils/build-script: fatal error: can't find clang (please install clang-3.5 or a later version)
+RUN ./$BUILD_SCRIPT build
+
+# Since swift is not compiling, run bash temporarily
+CMD bash

--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ To update and rebuild
 ```
 
 Once we get to a stable branch that builds on F23, I will switch the script to checking out that version instead of the wildly unstable 'master' branch. 
+
+## Docker
+To build on Docker, run the following command in the project directory:
+```
+docker build -t fedora-swift .
+```


### PR DESCRIPTION
I tried to wrap the fedora-swift build scripts in a Docker image.  Things work smoothly until `./swiftbuild.sh build` returns:

```
build
~/tmp/swiftbuild/swift /fedora-swift
utils/build-script: note: using preset 'buildbot_linux_build_fedora23', which expands to 

utils/build-script --assertions --release --llbuild --swiftpm --xctest --build-subdir=buildbot_linux --lldb --release --test --validation-test --foundation -- --swift-enable-ast-verifier=0 --install-swift --install-lldb --install-llbuild --install-swiftpm --install-xctest --install-prefix=/usr '--swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;dev' --build-swift-static-stdlib=1 --skip-test-lldb=1 --install-destdir=/root/tmp/swiftbuild/package --installable-package=/root/tmp/swiftbuild/package/swift-linux-x86_64-fedora-2017-02-01--18:44:14.tgz --verbose-build=1 --build-args=-j2 --install-foundation --reconfigure

utils/build-script: fatal error: can't find clang (please install clang-3.5 or a later version)
utils/build-script: fatal error: command terminated with a non-zero exit status 1, aborting
```

Clang does appear to be installed, so I am wondering if there is a missing clang command line parameter on `utils/build-script`